### PR TITLE
D10 Version support: Update ossearch_simple.info.yml

### DIFF
--- a/ossearch_simple.info.yml
+++ b/ossearch_simple.info.yml
@@ -2,7 +2,6 @@ name: Smithsonian Open Source Search
 type: module
 description: Admin UI for creating and editing simple search forms and results
 package: Smithsonian
-core: 8.x
-core_version_requirement: ^8 || ^9
+core_version_requirement: ^8 || ^9 || ^10
 dependencies:
   - drupal:block


### PR DESCRIPTION
Added Drupal 10 support, removed obsolete "core:" key that was used prior to Drupal 8.7.7 (8.8 and up use core_version_requirement)